### PR TITLE
Add periodic frame pair metrics and UI selection

### DIFF
--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -79,5 +79,6 @@ T_WINDOW: Final[int] = 100
 BOLLINGER_NUM_STD_OF_BANDS: Final[float] = 2.0
 DEFAULT_SUPER_PIXEL_SHAPE: Final[Tuple[int, int]] = (1, 1)
 WEBCAM_RETRY_INTERVAL_SECONDS: Final[int] = 2  # The frame polling interval when failing to retrieve a frame
-FRAME_WINDOW_SIZE: Final[int] = 2  # The spacing of frames between each flow calculation
+FRAME_WINDOW_SIZE: Final[int] = 5  # Number of frames captured each interval
+CAPTURE_INTERVAL_MINUTES: Final[int] = 10  # Interval between capture sessions
 DEFAULT_SUPER_PIXEL_DIMEMSNIONS = (4, 4)

--- a/main.py
+++ b/main.py
@@ -2,10 +2,8 @@ import sys
 import numpy as np
 import cv2 as cv
 from typing import Tuple
-from collections import deque
 from datetime import datetime
 from time import sleep
-from timer import Timer
 from metrics_extractor import extract_farneback_metric, extract_TVL1_metric, \
                                 extract_lucas_kanade_metric, extract_metrics, append_metrics
 import live_bollinger_gui
@@ -43,20 +41,6 @@ def get_next_frame(video_capture_object: cv.VideoCapture,
     return ret, frame
 
 
-def process_frame_window(frames: deque, metric_extractors):
-    current_timestamp = datetime.now()
-
-    if len(frames) < 2:
-        raise RuntimeError("frame window size must have at least 2 frames.")
-    
-    frame1 = frames[0]   # take first frame in frame window
-    frame2 = frames[-1]  # take last frame in frame window
-
-    metrics = extract_metrics(frame1, frame2, metric_extractors)
-    
-    return metrics
-
-
 def main():
     # is_webcam = True
     # # If program was used:
@@ -74,125 +58,73 @@ def main():
         # video_source = sys.argv[1]
         video_source = VIDEO_SOURCE["FILE"]
         
-    video_capture_object = cv.VideoCapture(video_source)
-
-    batch_size = conf.FRAME_WINDOW_SIZE  # Number of frames in the sliding window
-
-    if not video_capture_object.isOpened():
-        if is_webcam:
-            raise IOError(f"Cannot open webcam.")
-        else:
-            raise IOError(f"Cannot open video file: {video_source}.")
-
-    timer_object = Timer()
-
-    super_pixel_dimensions = conf.DEFAULT_SUPER_PIXEL_DIMEMSNIONS  # can be modified
+    super_pixel_dimensions = conf.DEFAULT_SUPER_PIXEL_DIMEMSNIONS
     frame_window_size = conf.FRAME_WINDOW_SIZE
 
-    frame_window = deque()  # Init as deque so i can pop left with minimal overhead
+    chart = live_bollinger_gui.MultiBollingerChart(
+        t_window=conf.T_WINDOW, num_std=conf.BOLLINGER_NUM_STD_OF_BANDS
+    )
 
-    for i in range(frame_window_size):
-        ret, frame = get_next_frame(video_capture_object, super_pixel_dimensions)  # Read a frame
-
-        if not ret:
-            if is_webcam:
-                print("Error: ")
-                # added a sleep() here so it won't retry in a short-circuit loop that might
-                # cause the webcam driver to cry
-                sleep(conf.WEBCAM_RETRY_INTERVAL_SECONDS)
-            else:
-                print("Error: End of video too soon")
-                break
-
-        frame_window.append(frame)
-
-    timer_object.tick()  # Start the clock
-
-    # Setup the GUI
-    chart = live_bollinger_gui.MultiBollingerChart(t_window=conf.T_WINDOW, num_std=conf.BOLLINGER_NUM_STD_OF_BANDS)
+    # prepare the metric extractors
+    metric_extractors = {
+        "Lucas-Kanade": {
+            "kwargs": conf.DEFAULT_LUCAS_KANADE_PARAMS,
+            "function": extract_lucas_kanade_metric,
+        },
+        "Farneback": {
+            "kwargs": conf.DEFAULT_FARNEBACK_PARAMS,
+            "function": extract_farneback_metric,
+        },
+        "TVL1": {"kwargs": conf.DEFAULT_TVL1_PARAMS, "function": extract_TVL1_metric},
+    }
 
     try:
-        frame_count = frame_window_size    
-        now = timer_object.start_time
-        output_prefix = f'{now.year}-{now.month:02d}-{now.day:02d}-{now.hour:02d}-{now.minute:02d}'
-
-        if is_webcam:
-            output_suffix = 'time_sec'
-        else:  # is video file
-            output_suffix = 'frame_count'
-
-        # prepare the metric extractors
-        metric_extractors = dict()
-        metric_extractors["Lucas-Kanade"] = {
-            "kwargs": conf.DEFAULT_LUCAS_KANADE_PARAMS,
-            "function": extract_lucas_kanade_metric
-        }
-        metric_extractors["Farneback"] = {
-            "kwargs": conf.DEFAULT_FARNEBACK_PARAMS,
-            "function": extract_farneback_metric
-        }
-        metric_extractors["TVL1"] = {
-            "kwargs": conf.DEFAULT_TVL1_PARAMS,
-            "function": extract_TVL1_metric
-        }
-        # TODO: add more metric extractors here. (function: Func[frame1, frame2, params/kwargs...] => Dict)
-
         while True:
-            ret, frame = get_next_frame(video_capture_object, super_pixel_dimensions)  # Read a frame
+            video_capture_object = cv.VideoCapture(video_source)
 
-            if not ret:
+            if not video_capture_object.isOpened():
                 if is_webcam:
-                    print("Error: ")
-                    # added a sleep() here so it won't retry in a short-circuit loop that might
-                    # cause the webcam driver to cry :(
-                    sleep(conf.WEBCAM_RETRY_INTERVAL_SECONDS)
-                else: # video source is a file
-                    print("End of video")
+                    raise IOError("Cannot open webcam.")
+                else:
+                    raise IOError(f"Cannot open video source: {video_source}.")
+
+            frame_window = []
+            for _ in range(frame_window_size):
+                ret, frame = get_next_frame(video_capture_object, super_pixel_dimensions)
+                if not ret:
                     break
+                frame_window.append(frame)
 
-            frame_window.popleft()
-            frame_window.append(frame)
+            video_capture_object.release()
 
-            if is_webcam:  # t-axis is elapsed seconds
-                # taking the elapsed before, so i can know the time of when the last frame was taken.
-                elapsed_seconds = timer_object.tock() // 1_000_000  # convert microsec to sec
-                elapsed_t_units = elapsed_seconds
-            else:  # If file then the t-axis is frame count
-                elapsed_t_units = frame_count
+            if len(frame_window) < frame_window_size:
+                print("Unable to capture enough frames")
+                break
 
-            # NOTE: this is the HEAVY function
-            # metrics is now a dictionary of the form: {"varient_name": <metrics dictionary>}
-            metrics = process_frame_window(frame_window, metric_extractors)
+            timestamp = datetime.now().isoformat()
+            date_stamp = datetime.now().strftime("%Y%m%d")
+            output_file_path = f"./output/{date_stamp}.csv"
 
-            # get flow matrix from farneback separately
-            flow = metrics["Farneback"]["flow_matrix"]
+            pair_metrics = {}
+            for idx in range(1, frame_window_size):
+                pair_name = f"1-{idx+1}"
+                metrics = extract_metrics(frame_window[0], frame_window[idx], metric_extractors)
+                append_metrics(output_file_path, metrics, timestamp, pair_name)
+                pair_metrics[pair_name] = metrics
 
-            # log the metrics with the elapsed units
-            output_file_path = f'./output/{output_prefix}_{video_source.split("/")[-1][:15]}_flow_metrics_{output_suffix}.csv'
-            append_metrics(output_file_path, metrics, elapsed_t_units)
-
-            # display updating video and graph
             data_dict = {}
-
-            # NOTE: decide which data to provide to the Bollinger chart
-
-            # # Display all metrics on the bollinger chart:
-            # for line in metric_extractors.keys():
-            #     data_dict[f'{line}_magnitude_mean'] = (metrics["Farneback"]['magnitude_mean'], metrics["Farneback"]['magnitude_deviation'])
-            #     data_dict[f'{line}_angular_mean'] = (metrics["Farneback"]['angular_mean'], metrics["Farneback"]['angular_deviation'])
-
-            # Display only the Farneback metrics to the bollinger chart:
-            data_dict["Farneback_magnitude_mean"] = (metrics["Farneback"]['magnitude_mean'], metrics["Farneback"]['magnitude_deviation'])
-
-            # Note: Doesn't work yet:
-            # data_dict["Farneback_angular_mean"] = (metrics["Farneback"]['angular_mean'], metrics["Farneback"]['angular_deviation'])
-            
+            for pair_name, metrics in pair_metrics.items():
+                fb = metrics["Farneback"]
+                data_dict[f"{pair_name}:Farneback_magnitude_mean"] = (
+                    fb["magnitude_mean"],
+                    fb["magnitude_deviation"],
+                )
+            flow = pair_metrics["1-2"]["Farneback"]["flow_matrix"]
             chart.push_new_data(data_dict, frame_window[0], flow)
 
-            frame_count += 1
+            sleep(conf.CAPTURE_INTERVAL_MINUTES * 60)
 
-    finally:  # release resources
-        video_capture_object.release()
+    finally:
         cv.destroyAllWindows()
 
 

--- a/metrics_extractor.py
+++ b/metrics_extractor.py
@@ -206,29 +206,28 @@ def calculate_flow_metrics(flow: np.ndarray):
     }
 
 
-def append_metrics(output_path: str, metrics, time_units):
+def append_metrics(output_path: str, metrics, time_units, frame_pair: str):
      # Make sure all parent directories exist
     directory = os.path.dirname(output_path)
-    if directory:  # Only try to create if there's an actual directory path
+    if directory:
         os.makedirs(directory, exist_ok=True)
-    
-    # If file doesn't exist, we'll need to write the header
+
     file_exists = os.path.exists(output_path)
-    
+
     with open(output_path, mode='a', newline='') as file:
         writer = csv.writer(file)
-        # Write header if this is a new file
         if not file_exists:
-            writer.writerow(["metric_name",
-                             "time", 
-                             "magnitude_mean", 
-                             "magnitude_deviation", 
-                             "angular_deviation", 
+            writer.writerow(["frame_pair",
+                             "metric_name",
+                             "time",
+                             "magnitude_mean",
+                             "magnitude_deviation",
+                             "angular_deviation",
                              "angular_mean"])
 
         for metric_name in metrics.keys():
-            # Append the data row
             writer.writerow([
+                frame_pair,
                 metric_name,
                 time_units,
                 metrics[metric_name]['magnitude_mean'],


### PR DESCRIPTION
## Summary
- Capture five-frame windows and compute metrics for pairs 1-2 through 1-5 every configured interval
- Log metrics with frame pair identifiers to a daily CSV file and expose capture interval in configuration
- Extend Bollinger UI with a radio button selector to toggle which frame pair's metrics are displayed
- Consolidate capture interval into cv_fish_configuration and remove standalone configuration module

## Testing
- `python -m py_compile cv_fish_configuration.py metrics_extractor.py main.py live_bollinger_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7b2e2e58832d8077f598dcb7e898