### PR TITLE
Add periodic frame sampling and multi-pair metrics visualization

### DIFF
--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -79,5 +79,8 @@ T_WINDOW: Final[int] = 100
 BOLLINGER_NUM_STD_OF_BANDS: Final[float] = 2.0
 DEFAULT_SUPER_PIXEL_SHAPE: Final[Tuple[int, int]] = (1, 1)
 WEBCAM_RETRY_INTERVAL_SECONDS: Final[int] = 2  # The frame polling interval when failing to retrieve a frame
-FRAME_WINDOW_SIZE: Final[int] = 2  # The spacing of frames between each flow calculation
+# Number of frames to capture in each sampling window
+FRAME_WINDOW_SIZE: Final[int] = 5
+# Interval between capture sessions in minutes
+CAPTURE_INTERVAL_MINUTES: Final[int] = 10
 DEFAULT_SUPER_PIXEL_DIMEMSNIONS = (4, 4)

--- a/live_bollinger_gui.py
+++ b/live_bollinger_gui.py
@@ -1,273 +1,198 @@
 import time
+from collections import defaultdict
 import numpy as np
 import matplotlib.pyplot as plt
-import cv_fish_configuration as conf
+from matplotlib.widgets import Dropdown
+
 
 plt.ion()  # Interactive mode to update plots without blocking
 
-class MultiBollingerChart:
-    """
-    A class that manages multiple Bollinger-like lines on the left subplot
-    and displays a frame + optical flow overlay on the right subplot.
 
-    Each call to push_new_data() can provide:
-      - A dictionary of line_name -> (value, std) for Bollinger lines
-      - A frame (np.ndarray) to display in the right subplot
-      - A flow (np.ndarray, shape=(H, W, 2)) to overlay via quiver
-    """
+class MultiPairBollingerChart:
+    """Display Bollinger metrics for multiple frame pairs with a dropdown selector."""
 
-    def __init__(self, t_window: float = 10.0, num_std: float = 2.0):
-        """
-        :param t_window: How many seconds of data to keep visible on the x-axis.
-        :param num_std: Multiplier for standard deviations (upper/lower bands).
-        """
+    def __init__(self, pair_labels, t_window: float = 10.0, num_std: float = 2.0):
         self.t_window = t_window
         self.num_std = num_std
+        self.pair_labels = pair_labels
+        self.current_pair = pair_labels[0]
 
-        # For Bollinger data:
+        # Data storage
         self.line_data = {}
+        self.pair_map = defaultdict(list)
+        self.frames = {p: None for p in pair_labels}
+        self.flows = {p: None for p in pair_labels}
 
-        # Create a figure with 2 subplots: left for Bollinger, right for image/flow
+        # Create figure and axes
         self.fig, (self.ax_boll, self.ax_img) = plt.subplots(1, 2, figsize=(10, 5))
-
-        # Set up Bollinger axis
         self.ax_boll.set_xlim(0, self.t_window)
         self.ax_boll.set_xlabel("Time (seconds, recent window)")
         self.ax_boll.set_ylabel("Value (+/- std dev)")
 
-        # For the image + flow overlay
-        self.im = None              # Will be a handle to the displayed image
-        self.quiver = None          # Will be a handle to the quiver plot
+        self.im = None
+        self.quiver = None
         self.ax_img.set_title("Latest Frame + Flow")
-        self.ax_img.axis("off")     # Hide axis ticks on the image subplot
+        self.ax_img.axis("off")
 
-    def push_new_data(
-        self, 
-        data_dict: dict[str, tuple[float, float]] = None,
-        frame: np.ndarray = None,
-        flow: np.ndarray = None
-    ):
-        """
-        Adds new Bollinger data (line_name -> (value, std)), plus optionally
-        updates the displayed frame and flow in the right subplot.
+        # Dropdown to choose pair
+        ax_dropdown = self.fig.add_axes([0.25, 0.95, 0.5, 0.04])
+        self.dropdown = Dropdown(ax_dropdown, "Pair", pair_labels, value=self.current_pair)
+        self.dropdown.on_changed(self._on_pair_change)
 
-        :param data_dict: e.g. {
-            "LineA": (valA, stdA),
-            "LineB": (valB, stdB)
-        }
-        :param frame: An optional image (2D or 3D np.ndarray) to display
-        :param flow: An optional dense flow array of shape (H, W, 2)
-                     from e.g. cv2.calcOpticalFlowFarneback
-        """
-        now = time.time()
-
-        # 1) Update Bollinger lines
-        if data_dict is not None:
-            for line_name, (val, std) in data_dict.items():
-                if line_name not in self.line_data:
-                    self._create_line(line_name)
-                self.line_data[line_name]["times"].append(now)
-                self.line_data[line_name]["values"].append(val)
-                self.line_data[line_name]["stdevs"].append(std)
-
-        self._update_bollinger_plot()
-
-        # 2) Update the frame on the right
-        if frame is not None:
-            self._update_image(frame)
-
-        # 3) Overlay flow quiver on the same right subplot
-        if flow is not None:
-            # Overlays the flow vectors on top of the current image
-            # (If no frame was provided, it still draws on the right axis)
-            self._update_flow_quiver(flow, step=60)
-
-        # 4) Redraw
+    def _on_pair_change(self, label):
+        self.current_pair = label
+        self._set_line_visibility()
+        if self.frames[label] is not None:
+            self._update_image(self.frames[label])
+        if self.flows[label] is not None:
+            self._update_flow_quiver(self.flows[label], step=60)
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()
 
-    def _create_line(self, line_name: str):
-        """
-        Internal helper to create a new line (value, upper, lower)
-        for a given line_name with a unique color from Matplotlib.
-        """
-        line_val, = self.ax_boll.plot([], [], label=f"{line_name} (value)")
+    def push_new_data(
+        self,
+        data_dict: dict[str, tuple[float, float]] = None,
+        frame: np.ndarray = None,
+        flow: np.ndarray = None,
+        pair_name: str = None,
+    ):
+        now = time.time()
+        if pair_name is None:
+            pair_name = self.current_pair
+
+        if data_dict is not None:
+            for line_name, (val, std) in data_dict.items():
+                key = f"{pair_name}_{line_name}"
+                if key not in self.line_data:
+                    self._create_line(key)
+                    self.pair_map[pair_name].append(key)
+                ld = self.line_data[key]
+                ld["times"].append(now)
+                ld["values"].append(val)
+                ld["stdevs"].append(std)
+
+        if frame is not None:
+            self.frames[pair_name] = frame
+            if pair_name == self.current_pair:
+                self._update_image(frame)
+
+        if flow is not None:
+            self.flows[pair_name] = flow
+            if pair_name == self.current_pair:
+                self._update_flow_quiver(flow, step=60)
+
+        self._update_bollinger_plot()
+        self.fig.canvas.draw()
+        self.fig.canvas.flush_events()
+
+    def _create_line(self, key: str):
+        line_val, = self.ax_boll.plot([], [], label=f"{key} (value)")
         base_color = line_val.get_color()
-
-        line_up, = self.ax_boll.plot([], [], label=f"{line_name} (upper)",
-                                     color=base_color, alpha=0.35)
-        line_down, = self.ax_boll.plot([], [], label=f"{line_name} (lower)",
-                                       color=base_color, alpha=0.35)
-
-        self.line_data[line_name] = {
+        line_up, = self.ax_boll.plot([], [], label=f"{key} (upper)", color=base_color, alpha=0.35)
+        line_down, = self.ax_boll.plot([], [], label=f"{key} (lower)", color=base_color, alpha=0.35)
+        self.line_data[key] = {
             "times": [],
             "values": [],
             "stdevs": [],
             "line_val": line_val,
             "line_upper": line_up,
-            "line_lower": line_down
+            "line_lower": line_down,
         }
+        self._set_line_visibility()
 
+    def _set_line_visibility(self):
+        for pair, keys in self.pair_map.items():
+            visible = pair == self.current_pair
+            for key in keys:
+                self.line_data[key]["line_val"].set_visible(visible)
+                self.line_data[key]["line_upper"].set_visible(visible)
+                self.line_data[key]["line_lower"].set_visible(visible)
         self.ax_boll.legend()
 
     def _update_bollinger_plot(self):
-        """
-        Removes data older than now - t_window for each line,
-        then updates line data for plotting.
-        """
         now = time.time()
         cutoff = now - self.t_window
-
-        for line_name, data in self.line_data.items():
+        for data in self.line_data.values():
             times_array = np.array(data["times"])
             vals_array = np.array(data["values"])
             stds_array = np.array(data["stdevs"])
-
-            valid_mask = (times_array >= cutoff)
+            valid_mask = times_array >= cutoff
             times_filtered = times_array[valid_mask]
             vals_filtered = vals_array[valid_mask]
             stds_filtered = stds_array[valid_mask]
-
             data["times"] = list(times_filtered)
             data["values"] = list(vals_filtered)
             data["stdevs"] = list(stds_filtered)
-
             if len(times_filtered) == 0:
-                # Clear lines if no data in the window
                 data["line_val"].set_data([], [])
                 data["line_upper"].set_data([], [])
                 data["line_lower"].set_data([], [])
                 continue
-
-            # SHIFT X to 0..t_window so the oldest point is x=0, newest is ~ x=t_window
             x_values = times_filtered - cutoff
-
             upper = vals_filtered + self.num_std * stds_filtered
             lower = vals_filtered - self.num_std * stds_filtered
-
             data["line_val"].set_data(x_values, vals_filtered)
             data["line_upper"].set_data(x_values, upper)
             data["line_lower"].set_data(x_values, lower)
-
-        # Keep x-axis [0..t_window]
         self.ax_boll.set_xlim(0, self.t_window)
-
-        # Autoscale y
         self.ax_boll.relim()
         self.ax_boll.autoscale_view(scalex=False, scaley=True)
 
     def _update_image(self, frame: np.ndarray):
-        """
-        Displays the given 'frame' (numpy array) in the right subplot.
-        If it's the first time, we create an image handle; otherwise, we update it.
-        """
         if self.im is None:
             self.im = self.ax_img.imshow(frame)
         else:
             self.im.set_data(frame)
-
-        # Adjust axis
         self.ax_img.set_title("Latest Frame + Flow")
         self.ax_img.axis("off")
 
     def _update_flow_quiver(self, flow: np.ndarray, step: int = 15):
-        """
-        Overlays a quiver (arrow) plot of the flow on top of the right subplot.
-        :param flow: np.ndarray of shape (H, W, 2), each pixel has (flow_x, flow_y).
-        :param step: sampling distance for quiver (to avoid too many arrows)
-                     e.g., step=15 means we sample every 15 pixels in x and y.
-        """
         if flow.ndim != 3 or flow.shape[2] != 2:
             print("Flow must be shape (H, W, 2). Skipping quiver.")
             return
-
-        # Remove old quiver (if any)
         if self.quiver is not None:
             self.quiver.remove()
             self.quiver = None
-
         H, W, _ = flow.shape
-
-        # Generate a coarse grid of sample points
-        # e.g. we take y=range(0,H,step), x=range(0,W,step)
         y_indices, x_indices = np.mgrid[0:H:step, 0:W:step]
-
-        # Flatten them for quiver
         X = x_indices.flatten()
         Y = y_indices.flatten()
-
-        # Flow vectors (U,V)
         U = flow[Y, X, 0]
         V = flow[Y, X, 1]
-
-        # Quiver: Y is row, so invert it if your coordinate system differs.
-        # Typically, image coords have Y increasing downward, so we might do -V if we want "up" in the positive direction.
         self.quiver = self.ax_img.quiver(
-            X, Y, U, V,
+            X,
+            Y,
+            U,
+            V,
             color='red',
             units='xy',
             angles='xy',
             scale_units='xy',
-
-            # Make arrows bigger (smaller 'scale' => longer arrows)
             scale=0.05,
-
-            # Pivot: 'tail' => (X,Y) is at arrow tail; 'mid' => arrow centered on (X,Y);
-            #        'tip' => arrow tip is at (X,Y).
             pivot='tail',
-
-            # Increase arrow thickness
             width=0.005,
-
-            # Increase arrowhead size
             headwidth=10,
             headlength=12,
             headaxislength=8,
-
-            # Optional: outline thickness and color
             linewidths=0.7,
-            edgecolors='yellow', 
-
-            alpha=1.0,  # fully opaque
-            zorder=2    # drawn above the image
+            edgecolors='yellow',
+            alpha=1.0,
+            zorder=2,
         )
-        
-        # Make sure the axis matches the image's dimension
         self.ax_img.set_xlim(0, W)
-        self.ax_img.set_ylim(H, 0)  # Flip y so 0 is at the top
+        self.ax_img.set_ylim(H, 0)
 
 
-# ------------------------------------------------------------------------------
-# Example usage
-# ------------------------------------------------------------------------------
 if __name__ == "__main__":
+    chart = MultiPairBollingerChart(["1-2", "1-3", "1-4", "1-5"], t_window=10, num_std=2.0)
     import random
-    
-    chart = MultiBollingerChart(t_window=10, num_std=2.0)
-
-    # For demonstration, we'll update 2 lines: "LineA" and "LineB".
-    line_names = ["LineA", "LineB"]
-
-    for i in range(30):
-        # Create some random Bollinger data
-        data_dict = {}
-        for ln in line_names:
-            offset = {"LineA": 0, "LineB": 20}[ln]
-            val = 100 + offset + random.gauss(0, 1)
-            std = random.uniform(0.5, 2.0)
-            data_dict[ln] = (val, std)
-
-        # Create a random 100x150 grayscale image
-        H, W = 100, 150
-        frame = np.random.randint(0, 255, (H, W), dtype=np.uint8)
-
-        # Create a random flow field (H, W, 2)
-        # For real use, you'd have something from cv2.calcOpticalFlowFarneback(...)
-        flow = np.random.randn(H, W, 2).astype(np.float32) * 2.0
-
-        # Send everything to the chart at once
-        chart.push_new_data(data_dict, frame=frame, flow=flow)
-
+    for i in range(5):
+        for pair in ["1-2", "1-3", "1-4", "1-5"]:
+            val = random.random()
+            std = random.random()
+            frame = np.random.randint(0, 255, (100, 150), dtype=np.uint8)
+            flow = np.random.randn(100, 150, 2).astype(np.float32)
+            chart.push_new_data({"Farneback_magnitude_mean": (val, std)}, frame=frame, flow=flow, pair_name=pair)
         time.sleep(0.5)
-
     input("Press Enter to exit...")
+

--- a/main.py
+++ b/main.py
@@ -2,12 +2,15 @@ import sys
 import numpy as np
 import cv2 as cv
 from typing import Tuple
-from collections import deque
 from datetime import datetime
 from time import sleep
-from timer import Timer
-from metrics_extractor import extract_farneback_metric, extract_TVL1_metric, \
-                                extract_lucas_kanade_metric, extract_metrics, append_metrics
+from metrics_extractor import (
+    extract_farneback_metric,
+    extract_TVL1_metric,
+    extract_lucas_kanade_metric,
+    extract_metrics,
+    append_metrics,
+)
 import live_bollinger_gui
 import cv_fish_configuration as conf
 
@@ -27,34 +30,30 @@ VIDEO_SOURCE = {
 }
 
 
-def get_next_frame(video_capture_object: cv.VideoCapture, 
-                   super_pixel_shape: Tuple[int, int]=conf.DEFAULT_SUPER_PIXEL_SHAPE):
-    """
-    Getting the next frame, performing binning (applying super pixel here for enhanced performance).
-    """
+def get_next_frame(video_capture_object: cv.VideoCapture,
+                   super_pixel_shape: Tuple[int, int] = conf.DEFAULT_SUPER_PIXEL_SHAPE):
+    """Get the next frame and apply super pixel downscaling."""
     ret, frame = video_capture_object.read()
-
-    # apply super pixel preprocessing when retrieving frame
     if ret:
-        frame = cv.resize(frame, (frame.shape[1] // super_pixel_shape[1], 
-                                  frame.shape[0] // super_pixel_shape[0]),
-                                  interpolation=cv.INTER_LINEAR)
-
+        frame = cv.resize(
+            frame,
+            (frame.shape[1] // super_pixel_shape[1], frame.shape[0] // super_pixel_shape[0]),
+            interpolation=cv.INTER_LINEAR,
+        )
     return ret, frame
 
 
-def process_frame_window(frames: deque, metric_extractors):
-    current_timestamp = datetime.now()
-
-    if len(frames) < 2:
-        raise RuntimeError("frame window size must have at least 2 frames.")
-    
-    frame1 = frames[0]   # take first frame in frame window
-    frame2 = frames[-1]  # take last frame in frame window
-
-    metrics = extract_metrics(frame1, frame2, metric_extractors)
-    
-    return metrics
+def capture_sample(video_source: str, num_frames: int, super_pixel_dimensions: Tuple[int, int]):
+    """Capture a fixed number of frames from the given video source."""
+    cap = cv.VideoCapture(video_source)
+    frames = []
+    for _ in range(num_frames):
+        ret, frame = get_next_frame(cap, super_pixel_dimensions)
+        if not ret:
+            break
+        frames.append(frame)
+    cap.release()
+    return frames
 
 
 def main():
@@ -74,126 +73,52 @@ def main():
         # video_source = sys.argv[1]
         video_source = VIDEO_SOURCE["FILE"]
         
-    video_capture_object = cv.VideoCapture(video_source)
-
-    batch_size = conf.FRAME_WINDOW_SIZE  # Number of frames in the sliding window
-
-    if not video_capture_object.isOpened():
-        if is_webcam:
-            raise IOError(f"Cannot open webcam.")
-        else:
-            raise IOError(f"Cannot open video file: {video_source}.")
-
-    timer_object = Timer()
-
     super_pixel_dimensions = conf.DEFAULT_SUPER_PIXEL_DIMEMSNIONS  # can be modified
-    frame_window_size = conf.FRAME_WINDOW_SIZE
 
-    frame_window = deque()  # Init as deque so i can pop left with minimal overhead
+    # Prepare metric extractors once
+    metric_extractors = {
+        "Lucas-Kanade": {"kwargs": conf.DEFAULT_LUCAS_KANADE_PARAMS, "function": extract_lucas_kanade_metric},
+        "Farneback": {"kwargs": conf.DEFAULT_FARNEBACK_PARAMS, "function": extract_farneback_metric},
+        "TVL1": {"kwargs": conf.DEFAULT_TVL1_PARAMS, "function": extract_TVL1_metric},
+    }
 
-    for i in range(frame_window_size):
-        ret, frame = get_next_frame(video_capture_object, super_pixel_dimensions)  # Read a frame
+    pair_labels = [f"1-{i}" for i in range(2, conf.FRAME_WINDOW_SIZE + 1)]
+    chart = live_bollinger_gui.MultiPairBollingerChart(
+        pair_labels, t_window=conf.T_WINDOW, num_std=conf.BOLLINGER_NUM_STD_OF_BANDS
+    )
 
-        if not ret:
-            if is_webcam:
-                print("Error: ")
-                # added a sleep() here so it won't retry in a short-circuit loop that might
-                # cause the webcam driver to cry
-                sleep(conf.WEBCAM_RETRY_INTERVAL_SECONDS)
-            else:
-                print("Error: End of video too soon")
-                break
+    capture_interval = conf.CAPTURE_INTERVAL_MINUTES * 60
 
-        frame_window.append(frame)
+    while True:
+        frames = capture_sample(video_source, conf.FRAME_WINDOW_SIZE, super_pixel_dimensions)
+        if len(frames) < conf.FRAME_WINDOW_SIZE:
+            print("Failed to capture enough frames")
+            sleep(capture_interval)
+            continue
 
-    timer_object.tick()  # Start the clock
+        now = datetime.now()
+        date_str = now.strftime("%Y%m%d")
+        output_file_path = f"./output/{date_str}.csv"
+        time_stamp = now.isoformat()
 
-    # Setup the GUI
-    chart = live_bollinger_gui.MultiBollingerChart(t_window=conf.T_WINDOW, num_std=conf.BOLLINGER_NUM_STD_OF_BANDS)
+        for idx in range(1, conf.FRAME_WINDOW_SIZE):
+            metrics = extract_metrics(frames[0], frames[idx], metric_extractors)
+            pair_label = f"1-{idx+1}"
+            append_metrics(output_file_path, metrics, time_stamp, pair_label)
 
-    try:
-        frame_count = frame_window_size    
-        now = timer_object.start_time
-        output_prefix = f'{now.year}-{now.month:02d}-{now.day:02d}-{now.hour:02d}-{now.minute:02d}'
+            data_dict = {
+                "Farneback_magnitude_mean": (
+                    metrics["Farneback"]["magnitude_mean"],
+                    metrics["Farneback"]["magnitude_deviation"],
+                )
+            }
+            flow = metrics["Farneback"].get("flow_matrix")
+            chart.push_new_data(data_dict, frame=frames[0], flow=flow, pair_name=pair_label)
 
-        if is_webcam:
-            output_suffix = 'time_sec'
-        else:  # is video file
-            output_suffix = 'frame_count'
+        sleep(capture_interval)
 
-        # prepare the metric extractors
-        metric_extractors = dict()
-        metric_extractors["Lucas-Kanade"] = {
-            "kwargs": conf.DEFAULT_LUCAS_KANADE_PARAMS,
-            "function": extract_lucas_kanade_metric
-        }
-        metric_extractors["Farneback"] = {
-            "kwargs": conf.DEFAULT_FARNEBACK_PARAMS,
-            "function": extract_farneback_metric
-        }
-        metric_extractors["TVL1"] = {
-            "kwargs": conf.DEFAULT_TVL1_PARAMS,
-            "function": extract_TVL1_metric
-        }
-        # TODO: add more metric extractors here. (function: Func[frame1, frame2, params/kwargs...] => Dict)
-
-        while True:
-            ret, frame = get_next_frame(video_capture_object, super_pixel_dimensions)  # Read a frame
-
-            if not ret:
-                if is_webcam:
-                    print("Error: ")
-                    # added a sleep() here so it won't retry in a short-circuit loop that might
-                    # cause the webcam driver to cry :(
-                    sleep(conf.WEBCAM_RETRY_INTERVAL_SECONDS)
-                else: # video source is a file
-                    print("End of video")
-                    break
-
-            frame_window.popleft()
-            frame_window.append(frame)
-
-            if is_webcam:  # t-axis is elapsed seconds
-                # taking the elapsed before, so i can know the time of when the last frame was taken.
-                elapsed_seconds = timer_object.tock() // 1_000_000  # convert microsec to sec
-                elapsed_t_units = elapsed_seconds
-            else:  # If file then the t-axis is frame count
-                elapsed_t_units = frame_count
-
-            # NOTE: this is the HEAVY function
-            # metrics is now a dictionary of the form: {"varient_name": <metrics dictionary>}
-            metrics = process_frame_window(frame_window, metric_extractors)
-
-            # get flow matrix from farneback separately
-            flow = metrics["Farneback"]["flow_matrix"]
-
-            # log the metrics with the elapsed units
-            output_file_path = f'./output/{output_prefix}_{video_source.split("/")[-1][:15]}_flow_metrics_{output_suffix}.csv'
-            append_metrics(output_file_path, metrics, elapsed_t_units)
-
-            # display updating video and graph
-            data_dict = {}
-
-            # NOTE: decide which data to provide to the Bollinger chart
-
-            # # Display all metrics on the bollinger chart:
-            # for line in metric_extractors.keys():
-            #     data_dict[f'{line}_magnitude_mean'] = (metrics["Farneback"]['magnitude_mean'], metrics["Farneback"]['magnitude_deviation'])
-            #     data_dict[f'{line}_angular_mean'] = (metrics["Farneback"]['angular_mean'], metrics["Farneback"]['angular_deviation'])
-
-            # Display only the Farneback metrics to the bollinger chart:
-            data_dict["Farneback_magnitude_mean"] = (metrics["Farneback"]['magnitude_mean'], metrics["Farneback"]['magnitude_deviation'])
-
-            # Note: Doesn't work yet:
-            # data_dict["Farneback_angular_mean"] = (metrics["Farneback"]['angular_mean'], metrics["Farneback"]['angular_deviation'])
-            
-            chart.push_new_data(data_dict, frame_window[0], flow)
-
-            frame_count += 1
-
-    finally:  # release resources
-        video_capture_object.release()
-        cv.destroyAllWindows()
+    # Should never reach here but ensure clean up
+    cv.destroyAllWindows()
 
 
 if __name__ == '__main__':

--- a/metrics_extractor.py
+++ b/metrics_extractor.py
@@ -206,30 +206,31 @@ def calculate_flow_metrics(flow: np.ndarray):
     }
 
 
-def append_metrics(output_path: str, metrics, time_units):
+def append_metrics(output_path: str, metrics, time_units, pair_name: str = ""):
      # Make sure all parent directories exist
     directory = os.path.dirname(output_path)
     if directory:  # Only try to create if there's an actual directory path
         os.makedirs(directory, exist_ok=True)
-    
+
     # If file doesn't exist, we'll need to write the header
     file_exists = os.path.exists(output_path)
-    
+
     with open(output_path, mode='a', newline='') as file:
         writer = csv.writer(file)
         # Write header if this is a new file
         if not file_exists:
             writer.writerow(["metric_name",
-                             "time", 
-                             "magnitude_mean", 
-                             "magnitude_deviation", 
-                             "angular_deviation", 
+                             "time",
+                             "magnitude_mean",
+                             "magnitude_deviation",
+                             "angular_deviation",
                              "angular_mean"])
 
         for metric_name in metrics.keys():
             # Append the data row
+            name = f"{pair_name}_{metric_name}" if pair_name else metric_name
             writer.writerow([
-                metric_name,
+                name,
                 time_units,
                 metrics[metric_name]['magnitude_mean'],
                 metrics[metric_name]['magnitude_deviation'],


### PR DESCRIPTION
## Summary
- capture 5-frame samples at 10‑minute intervals and log metrics per frame pair
- support pair names when logging metrics
- add dropdown-driven Bollinger UI for selecting frame pair metrics

## Testing
- `python -m py_compile cv_fish_configuration.py metrics_extractor.py main.py live_bollinger_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_68a74a688bd4832da3fae57da1b26c06