### PR TITLE
Add Flask API and web dashboard for live metrics

### DIFF
--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -116,7 +116,7 @@ DEFAULT_SUPER_PIXEL_DIMEMSNIONS = (4, 4)
 # =============================================================================
 OUTPUT_DIR: Final[str] = "./output"
 # Latest frame saved by the metrics worker; stored as PNG to align with
-# persistent frame-window naming (frame<idx>-YYYYMMDD-hhmmss.png)
+# persistent frame-window naming (frame<idx>-YYYYMMDD-hhmm.png)
 LATEST_FRAME_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame.png")
 LATEST_TS_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame_timestamp.txt")
 FRAMES_DIR: Final[str] = os.path.join(OUTPUT_DIR, "frames")

--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -117,6 +117,7 @@ DEFAULT_SUPER_PIXEL_DIMEMSNIONS = (4, 4)
 OUTPUT_DIR: Final[str] = "./output"
 LATEST_FRAME_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame.jpg")
 LATEST_TS_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame_timestamp.txt")
+FRAMES_DIR: Final[str] = os.path.join(OUTPUT_DIR, "frames")
 
 
 # =============================================================================

--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -101,6 +101,9 @@ DEFAULT_SUPER_PIXEL_SHAPE: Final[Tuple[int, int]] = (1, 1)
 WEBCAM_RETRY_INTERVAL_SECONDS: Final[int] = 2
 """The frame polling interval when failing to retrieve a frame from the capture device."""
 
+CAPTURE_RETRY_ATTEMPTS: Final[int] = 3
+"""Number of times to reinitialise the capture device when frame collection fails."""
+
 # Number of frames to capture in each sampling window
 FRAME_WINDOW_SIZE: Final[int] = 5
 

--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -11,6 +11,7 @@ configuration at runtime, make a copy instead of mutating these
 structures directly.
 """
 
+import os
 import cv2
 from frozendict import frozendict
 from typing import Final, Tuple
@@ -108,3 +109,34 @@ CAPTURE_INTERVAL_MINUTES: Final[int] = 10
 
 DEFAULT_SUPER_PIXEL_DIMEMSNIONS = (4, 4)
 """Default dimensions used when downscaling frames for processing."""
+
+
+# =============================================================================
+# I/O paths and outputs:
+# =============================================================================
+OUTPUT_DIR: Final[str] = "./output"
+LATEST_FRAME_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame.jpg")
+LATEST_TS_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame_timestamp.txt")
+
+
+# =============================================================================
+# Video source configuration:
+# =============================================================================
+VIDOE_FILE_PATH: Final[str] = './Workable Data/Processed/DPH21_Above_IR10.avi'
+NVR_USER: Final[str] = 'admin'
+NVR_PASS: Final[str] = 'admin12345'
+NVR_IP: Final[str] = '0.0.0.0'  # within network
+NVR_PORT: Final[str] = '554'  # default port for the protocol, might not need change
+NVR_PATH: Final[str] = '/Streaming/Channels/101'
+VIDEO_SOURCE = frozendict({
+    'FILE': VIDOE_FILE_PATH,
+    'WEBCAM': 0,
+    'NVR': f"rtsp://{NVR_USER}:{NVR_PASS}@{NVR_IP}:{NVR_PORT}{NVR_PATH}"
+})
+
+
+# =============================================================================
+# Flask API configuration:
+# =============================================================================
+FLASK_HOST: Final[str] = '0.0.0.0'
+FLASK_PORT: Final[int] = 5000

--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -134,7 +134,9 @@ FRAMES_DIR: Final[str] = os.path.join(OUTPUT_DIR, "frames")
 VIDOE_FILE_PATH: Final[str] = './Workable Data/Processed/DPH21_Above_IR10.avi'
 NVR_USER: Final[str] = 'admin'
 NVR_PASS: Final[str] = 'admin12345'
-NVR_IP: Final[str] = '0.0.0.0'  # within network
+# IP of the network video recorder. Override via the NVR_IP environment
+# variable if necessary.
+NVR_IP: Final[str] = os.getenv('NVR_IP', '192.168.1.56')
 NVR_PORT: Final[str] = '554'  # default port for the protocol, might not need change
 NVR_PATH: Final[str] = '/Streaming/Channels/101'
 VIDEO_SOURCE = frozendict({

--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -115,7 +115,9 @@ DEFAULT_SUPER_PIXEL_DIMEMSNIONS = (4, 4)
 # I/O paths and outputs:
 # =============================================================================
 OUTPUT_DIR: Final[str] = "./output"
-LATEST_FRAME_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame.jpg")
+# Latest frame saved by the metrics worker; stored as PNG to align with
+# persistent frame-window naming (frame<idx>-YYYYMMDD-hhmmss.png)
+LATEST_FRAME_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame.png")
 LATEST_TS_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame_timestamp.txt")
 FRAMES_DIR: Final[str] = os.path.join(OUTPUT_DIR, "frames")
 

--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -110,13 +110,16 @@ CAPTURE_INTERVAL_MINUTES: Final[int] = 10
 DEFAULT_SUPER_PIXEL_DIMEMSNIONS = (4, 4)
 """Default dimensions used when downscaling frames for processing."""
 
+# Timestamp format used for metric rows and frame filenames
+TIMESTAMP_FORMAT: Final[str] = "%Y%m%d-%H%M%S"
+
 
 # =============================================================================
 # I/O paths and outputs:
 # =============================================================================
 OUTPUT_DIR: Final[str] = "./output"
 # Latest frame saved by the metrics worker; stored as PNG to align with
-# persistent frame-window naming (frame<idx>-YYYYMMDD-hhmm.png)
+# persistent frame-window naming (frame<idx>-YYYYMMDD-hhmmss.png)
 LATEST_FRAME_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame.png")
 LATEST_TS_PATH: Final[str] = os.path.join(OUTPUT_DIR, "latest_frame_timestamp.txt")
 FRAMES_DIR: Final[str] = os.path.join(OUTPUT_DIR, "frames")

--- a/cv_fish_configuration.py
+++ b/cv_fish_configuration.py
@@ -146,3 +146,7 @@ VIDEO_SOURCE = frozendict({
 # =============================================================================
 FLASK_HOST: Final[str] = '0.0.0.0'
 FLASK_PORT: Final[int] = 5000
+# Base URL used by background threads to report status back to the Flask API
+API_BASE_URL: Final[str] = f"http://127.0.0.1:{FLASK_PORT}"
+# Endpoint for worker success/error logging
+LOG_ENDPOINT: Final[str] = f"{API_BASE_URL}/logs"

--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
 
   # Web server
   - flask
+  - requests
 
   # Interactive work
   - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,9 @@ dependencies:
   - blobfile
   - spectral
 
+  # Web server
+  - flask
+
   # Interactive work
   - ipython
 

--- a/live_bollinger_gui.py
+++ b/live_bollinger_gui.py
@@ -48,6 +48,7 @@ class MultiPairBollingerChart:
         self.ax_boll.set_xlim(0, self.t_window)
         self.ax_boll.set_xlabel("Time (seconds, recent window)")
         self.ax_boll.set_ylabel("Value (+/- std dev)")
+        self.ax_boll.set_title(f"Pair {self.current_pair}")
 
         self.im = None
         self.quiver = None
@@ -67,6 +68,7 @@ class MultiPairBollingerChart:
             self._update_image(self.frames[label])
         if self.flows[label] is not None:
             self._update_flow_quiver(self.flows[label], step=60)
+        self.ax_boll.set_title(f"Pair {self.current_pair}")
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()
 
@@ -115,10 +117,11 @@ class MultiPairBollingerChart:
 
     def _create_line(self, key: str):
         """Initialise plot lines to track a new metric."""
-        line_val, = self.ax_boll.plot([], [], label=f"{key} (value)")
+        label = key.replace('_', ' ')
+        line_val, = self.ax_boll.plot([], [], label=f"{label} (value)")
         base_color = line_val.get_color()
-        line_up, = self.ax_boll.plot([], [], label=f"{key} (upper)", color=base_color, alpha=0.35)
-        line_down, = self.ax_boll.plot([], [], label=f"{key} (lower)", color=base_color, alpha=0.35)
+        line_up, = self.ax_boll.plot([], [], label=f"{label} (upper)", color=base_color, alpha=0.35)
+        line_down, = self.ax_boll.plot([], [], label=f"{label} (lower)", color=base_color, alpha=0.35)
         self.line_data[key] = {
             "times": [],
             "values": [],

--- a/main.py
+++ b/main.py
@@ -1,136 +1,71 @@
-import sys
-"""Capture frames, compute optical-flow metrics and update the UI.
+#!/usr/bin/env python3
+"""Run the metrics extraction thread and expose a Flask REST API."""
 
-This module orchestrates the full data-processing loop: it repeatedly
-captures a short window of frames from a configured video source,
-computes multiple optical-flow metrics for several frame pairs and logs
-the results to CSV while feeding the live Bollinger chart.
-"""
+from __future__ import annotations
 
-import numpy as np
-import cv2 as cv
-from typing import Tuple
-from datetime import datetime
-from metrics_extractor import (
-    extract_farneback_metric,
-    extract_TVL1_metric,
-    extract_lucas_kanade_metric,
-    extract_metrics,
-    append_metrics,
-)
-import live_bollinger_gui
-import cv_fish_configuration as conf
+import csv
+import glob
+import os
+import threading
+from flask import Flask, jsonify, make_response, render_template, send_file
 
-VIDOE_FILE_PATH = './Workable Data/Processed/DPH21_Above_IR10.avi'
+from metrics_worker import start_metrics_thread
 
-# TODO: fill the correct data
-NVR_USER = 'admin'
-NVR_PASS = 'admin12345'
-NVR_IP = '0.0.0.0'  # within network
-NVR_PORT = '554'  # default port for the protocol, might not need change
-NVR_PATH = '/Streaming/Channels/101'
+app = Flask(__name__)
 
-VIDEO_SOURCE = {
-    'FILE': VIDOE_FILE_PATH,
-    'WEBCAM': 0,
-    'NVR': f"rtsp://{NVR_USER}:{NVR_PASS}@{NVR_IP}:{NVR_PORT}{NVR_PATH}"
-}
+OUTPUT_DIR = './output'
+LATEST_FRAME_PATH = os.path.join(OUTPUT_DIR, 'latest_frame.jpg')
+LATEST_TS_PATH = os.path.join(OUTPUT_DIR, 'latest_frame_timestamp.txt')
 
 
-def get_next_frame(video_capture_object: cv.VideoCapture,
-                   super_pixel_shape: Tuple[int, int] = conf.DEFAULT_SUPER_PIXEL_SHAPE):
-    """Get the next frame and apply super pixel downscaling."""
-    ret, frame = video_capture_object.read()
-    if ret:
-        frame = cv.resize(
-            frame,
-            (frame.shape[1] // super_pixel_shape[1], frame.shape[0] // super_pixel_shape[0]),
-            interpolation=cv.INTER_LINEAR,
-        )
-    return ret, frame
+def _latest_csv() -> str | None:
+    files = sorted(glob.glob(os.path.join(OUTPUT_DIR, '*.csv')))
+    return files[-1] if files else None
 
 
-def capture_sample(video_source: str, num_frames: int, super_pixel_dimensions: Tuple[int, int]):
-    """Capture a fixed number of frames from the given video source."""
-    cap = cv.VideoCapture(video_source)
-    frames = []
-    for _ in range(num_frames):
-        ret, frame = get_next_frame(cap, super_pixel_dimensions)
-        if not ret:
-            break
-        frames.append(frame)
-    cap.release()
-    return frames
+@app.route('/')
+def index():
+    """Serve the web UI."""
+    return render_template('index.html')
+
+
+@app.get('/metrics')
+def get_all_metrics():
+    """Return all metrics from the latest CSV file."""
+    csv_path = _latest_csv()
+    if csv_path is None:
+        return jsonify({'timestamp': None, 'metrics': []})
+    with open(csv_path, newline='') as fh:
+        reader = csv.DictReader(fh)
+        rows = list(reader)
+    ts = rows[-1]['time'] if rows else None
+    return jsonify({'timestamp': ts, 'metrics': rows})
+
+
+@app.get('/frame')
+def get_last_frame():
+    """Return the most recently saved frame with optical-flow quivers."""
+    if not os.path.exists(LATEST_FRAME_PATH):
+        return ('', 404)
+    ts = ''
+    if os.path.exists(LATEST_TS_PATH):
+        with open(LATEST_TS_PATH, encoding='utf-8') as fh:
+            ts = fh.read().strip()
+    response = make_response(send_file(LATEST_FRAME_PATH, mimetype='image/jpeg'))
+    if ts:
+        response.headers['X-Data-Timestamp'] = ts
+    return response
 
 
 def main():
-    """Continuously capture frame windows and process optical-flow metrics."""
-    # Determine which video source to use.  For now we favour the NVR
-    # stream but the logic is easily adaptable for other sources.
-    # is_webcam = True
-    # if len(sys.argv) > 1:
-    #     is_webcam = False
-    is_webcam = False
-    is_nvr = True
-
-    if is_webcam:
-        video_source = VIDEO_SOURCE["WEBCAM"]
-    elif is_nvr:
-        video_source = VIDEO_SOURCE["NVR"]
-    else:  # video source is a video file
-        # video_source = sys.argv[1]
-        video_source = VIDEO_SOURCE["FILE"]
-
-    super_pixel_dimensions = conf.DEFAULT_SUPER_PIXEL_DIMEMSNIONS  # can be modified
-
-    # Prepare metric extractors once
-    metric_extractors = {
-        "Lucas-Kanade": {"kwargs": conf.DEFAULT_LUCAS_KANADE_PARAMS, "function": extract_lucas_kanade_metric},
-        "Farneback": {"kwargs": conf.DEFAULT_FARNEBACK_PARAMS, "function": extract_farneback_metric},
-        "TVL1": {"kwargs": conf.DEFAULT_TVL1_PARAMS, "function": extract_TVL1_metric},
-    }
-
-    # Prepare the live chart UI and pair labels for frame comparisons
-    pair_labels = [f"1-{i}" for i in range(2, conf.FRAME_WINDOW_SIZE + 1)]
-    chart = live_bollinger_gui.MultiPairBollingerChart(
-        pair_labels, t_window=conf.T_WINDOW, num_std=conf.BOLLINGER_NUM_STD_OF_BANDS
-    )
-
-    capture_interval = conf.CAPTURE_INTERVAL_MINUTES * 60
-
-    while True:
-        # Capture a short sequence of frames from the source
-        frames = capture_sample(video_source, conf.FRAME_WINDOW_SIZE, super_pixel_dimensions)
-        if len(frames) < conf.FRAME_WINDOW_SIZE:
-            print("Failed to capture enough frames")
-            chart.wait_with_ui(capture_interval)
-            continue
-
-        now = datetime.now()
-        date_str = now.strftime("%Y%m%d")
-        output_file_path = f"./output/{date_str}.csv"
-        time_stamp = now.isoformat()
-
-        # Compare the first frame with every subsequent frame in the window
-        for idx in range(1, conf.FRAME_WINDOW_SIZE):
-            metrics = extract_metrics(frames[0], frames[idx], metric_extractors)
-            pair_label = f"1-{idx+1}"
-            append_metrics(output_file_path, metrics, time_stamp, pair_label)
-
-            data_dict = {
-                "Farneback_magnitude_mean": (
-                    metrics["Farneback"]["magnitude_mean"],
-                    metrics["Farneback"]["magnitude_deviation"],
-                )
-            }
-            flow = metrics["Farneback"].get("flow_matrix")
-            chart.push_new_data(data_dict, frame=frames[0], flow=flow, pair_name=pair_label)
-
-        # Wait before sampling again but keep the UI responsive
-        chart.wait_with_ui(capture_interval)
-
-    # Should never reach here but ensure clean up
-    cv.destroyAllWindows()
+    """Start the metrics thread and run the Flask development server."""
+    stop_event = threading.Event()
+    thread = start_metrics_thread(stop_event)
+    try:
+        app.run(host='0.0.0.0', port=5000)
+    finally:
+        stop_event.set()
+        thread.join()
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -54,7 +54,8 @@ def get_last_frame():
     if os.path.exists(conf.LATEST_TS_PATH):
         with open(conf.LATEST_TS_PATH, encoding='utf-8') as fh:
             ts = fh.read().strip()
-    response = make_response(send_file(conf.LATEST_FRAME_PATH, mimetype='image/jpeg'))
+    # Latest frame is stored as PNG; serve with matching mimetype
+    response = make_response(send_file(conf.LATEST_FRAME_PATH, mimetype='image/png'))
     if ts:
         response.headers['X-Data-Timestamp'] = ts
     return response
@@ -78,7 +79,7 @@ def list_frames(timestamp: str):
     for p in files:
         base = os.path.basename(p)
         idx = int(base.split('-', 1)[0].replace('frame', ''))
-        frames.append({'index': idx})
+        frames.append({'index': idx, 'filename': base})
     return jsonify({'timestamp': timestamp, 'frames': frames})
 
 

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def get_frame(timestamp: str | None = None):
     """Return a frame by timestamp or the most recent one if none given."""
     if timestamp is None:
         qs = request.query_string.decode('utf-8')
-        if re.fullmatch(r"\d{8}-\d{6}", qs):
+        if re.fullmatch(r"\d{8}-\d{4}", qs):
             timestamp = qs
     if timestamp:
         pattern = os.path.join(conf.FRAMES_DIR, f'frame*-{timestamp}.png')

--- a/main.py
+++ b/main.py
@@ -83,6 +83,25 @@ def list_frame_sets():
     return jsonify({'timestamps': timestamps})
 
 
+@app.get('/frames/all')
+def list_all_frames():
+    """Return all frame filenames grouped by their capture timestamp."""
+    pattern = os.path.join(conf.FRAMES_DIR, 'frame*-*.png')
+    files = sorted(glob.glob(pattern))
+    grouped: dict[str, list[dict[str, int | str]]] = {}
+    for path in files:
+        base = os.path.basename(path)
+        idx_part, ts_part = base.split('-', 1)
+        ts = ts_part.rsplit('.', 1)[0]
+        idx = int(idx_part.replace('frame', ''))
+        grouped.setdefault(ts, []).append({'index': idx, 'filename': base})
+    frame_sets = [
+        {'timestamp': ts, 'frames': sorted(frames, key=lambda f: f['index'])}
+        for ts, frames in sorted(grouped.items())
+    ]
+    return jsonify({'frame_sets': frame_sets})
+
+
 @app.get('/frames/<timestamp>')
 def list_frames(timestamp: str):
     """List frame indices available for a given capture timestamp."""

--- a/main.py
+++ b/main.py
@@ -54,6 +54,39 @@ def get_last_frame():
     return response
 
 
+@app.get('/frames')
+def list_frame_sets():
+    """Return all timestamps that have saved frame windows."""
+    pattern = os.path.join(conf.FRAMES_DIR, 'frame*-*.png')
+    files = glob.glob(pattern)
+    timestamps = sorted({os.path.basename(p).split('-', 1)[1].rsplit('.', 1)[0] for p in files})
+    return jsonify({'timestamps': timestamps})
+
+
+@app.get('/frames/<timestamp>')
+def list_frames(timestamp: str):
+    """List frame indices available for a given capture timestamp."""
+    pattern = os.path.join(conf.FRAMES_DIR, f'frame*-{timestamp}.png')
+    files = sorted(glob.glob(pattern))
+    frames = []
+    for p in files:
+        base = os.path.basename(p)
+        idx = int(base.split('-', 1)[0].replace('frame', ''))
+        frames.append({'index': idx})
+    return jsonify({'timestamp': timestamp, 'frames': frames})
+
+
+@app.get('/frames/<timestamp>/<int:index>')
+def get_frame_by_index(timestamp: str, index: int):
+    """Retrieve a specific frame image by timestamp and index."""
+    path = os.path.join(conf.FRAMES_DIR, f'frame{index}-{timestamp}.png')
+    if not os.path.exists(path):
+        return ('', 404)
+    response = make_response(send_file(path, mimetype='image/png'))
+    response.headers['X-Data-Timestamp'] = timestamp
+    return response
+
+
 def main():
     """Start the metrics thread and run the Flask development server."""
     stop_event = threading.Event()

--- a/main.py
+++ b/main.py
@@ -155,6 +155,11 @@ def get_logs():
 
 def main():
     """Start the metrics thread and run the Flask development server."""
+    # Log the RTSP source used for frame capture so operators know
+    # exactly which stream is being consumed.
+    rtsp_path = conf.VIDEO_SOURCE['NVR']
+    print(f"Capturing frames from RTSP source: {rtsp_path}")
+
     stop_event = threading.Event()
     thread = start_metrics_thread(stop_event)
     try:

--- a/main.py
+++ b/main.py
@@ -50,10 +50,11 @@ def favicon():
 @app.get('/frame/<timestamp>')
 def get_frame(timestamp: str | None = None):
     """Return a frame by timestamp or the most recent one if none given."""
-    if timestamp is None:
-        qs = request.query_string.decode('utf-8')
-        if re.fullmatch(r"\d{8}-\d{4}", qs):
-            timestamp = qs
+    qs_ts = request.args.get('timestamp')
+    if qs_ts and re.fullmatch(r"\d{8}-\d{6}", qs_ts):
+        timestamp = qs_ts
+    elif timestamp and not re.fullmatch(r"\d{8}-\d{6}", timestamp):
+        timestamp = None
     if timestamp:
         pattern = os.path.join(conf.FRAMES_DIR, f'frame*-{timestamp}.png')
         files = sorted(glob.glob(pattern))

--- a/main.py
+++ b/main.py
@@ -39,11 +39,17 @@ def get_all_metrics():
     return jsonify({'timestamp': ts, 'metrics': rows})
 
 
+@app.get('/favicon.ico')
+def favicon():
+    """Avoid unnecessary 404 errors for the browser favicon request."""
+    return ('', 204)
+
+
 @app.get('/frame')
 def get_last_frame():
     """Return the most recently saved frame with optical-flow quivers."""
     if not os.path.exists(conf.LATEST_FRAME_PATH):
-        return ('', 404)
+        return ('', 204)
     ts = ''
     if os.path.exists(conf.LATEST_TS_PATH):
         with open(conf.LATEST_TS_PATH, encoding='utf-8') as fh:

--- a/matplotlib_main.py
+++ b/matplotlib_main.py
@@ -7,6 +7,7 @@ computes multiple optical-flow metrics for several frame pairs and logs
 the results to CSV while feeding the live Bollinger chart.
 """
 
+import os
 import numpy as np
 import cv2 as cv
 from typing import Tuple
@@ -20,21 +21,6 @@ from metrics_extractor import (
 )
 import live_bollinger_gui
 import cv_fish_configuration as conf
-
-VIDOE_FILE_PATH = './Workable Data/Processed/DPH21_Above_IR10.avi'
-
-# TODO: fill the correct data
-NVR_USER = 'admin'
-NVR_PASS = 'admin12345'
-NVR_IP = '0.0.0.0'  # within network
-NVR_PORT = '554'  # default port for the protocol, might not need change
-NVR_PATH = '/Streaming/Channels/101'
-
-VIDEO_SOURCE = {
-    'FILE': VIDOE_FILE_PATH,
-    'WEBCAM': 0,
-    'NVR': f"rtsp://{NVR_USER}:{NVR_PASS}@{NVR_IP}:{NVR_PORT}{NVR_PATH}"
-}
 
 
 def get_next_frame(video_capture_object: cv.VideoCapture,
@@ -74,12 +60,12 @@ def main():
     is_nvr = True
 
     if is_webcam:
-        video_source = VIDEO_SOURCE["WEBCAM"]
+        video_source = conf.VIDEO_SOURCE["WEBCAM"]
     elif is_nvr:
-        video_source = VIDEO_SOURCE["NVR"]
+        video_source = conf.VIDEO_SOURCE["NVR"]
     else:  # video source is a video file
         # video_source = sys.argv[1]
-        video_source = VIDEO_SOURCE["FILE"]
+        video_source = conf.VIDEO_SOURCE["FILE"]
 
     super_pixel_dimensions = conf.DEFAULT_SUPER_PIXEL_DIMEMSNIONS  # can be modified
 
@@ -108,7 +94,7 @@ def main():
 
         now = datetime.now()
         date_str = now.strftime("%Y%m%d")
-        output_file_path = f"./output/{date_str}.csv"
+        output_file_path = os.path.join(conf.OUTPUT_DIR, f"{date_str}.csv")
         time_stamp = now.isoformat()
 
         # Compare the first frame with every subsequent frame in the window

--- a/matplotlib_main.py
+++ b/matplotlib_main.py
@@ -1,0 +1,137 @@
+import sys
+"""Capture frames, compute optical-flow metrics and update the UI.
+
+This module orchestrates the full data-processing loop: it repeatedly
+captures a short window of frames from a configured video source,
+computes multiple optical-flow metrics for several frame pairs and logs
+the results to CSV while feeding the live Bollinger chart.
+"""
+
+import numpy as np
+import cv2 as cv
+from typing import Tuple
+from datetime import datetime
+from metrics_extractor import (
+    extract_farneback_metric,
+    extract_TVL1_metric,
+    extract_lucas_kanade_metric,
+    extract_metrics,
+    append_metrics,
+)
+import live_bollinger_gui
+import cv_fish_configuration as conf
+
+VIDOE_FILE_PATH = './Workable Data/Processed/DPH21_Above_IR10.avi'
+
+# TODO: fill the correct data
+NVR_USER = 'admin'
+NVR_PASS = 'admin12345'
+NVR_IP = '0.0.0.0'  # within network
+NVR_PORT = '554'  # default port for the protocol, might not need change
+NVR_PATH = '/Streaming/Channels/101'
+
+VIDEO_SOURCE = {
+    'FILE': VIDOE_FILE_PATH,
+    'WEBCAM': 0,
+    'NVR': f"rtsp://{NVR_USER}:{NVR_PASS}@{NVR_IP}:{NVR_PORT}{NVR_PATH}"
+}
+
+
+def get_next_frame(video_capture_object: cv.VideoCapture,
+                   super_pixel_shape: Tuple[int, int] = conf.DEFAULT_SUPER_PIXEL_SHAPE):
+    """Get the next frame and apply super pixel downscaling."""
+    ret, frame = video_capture_object.read()
+    if ret:
+        frame = cv.resize(
+            frame,
+            (frame.shape[1] // super_pixel_shape[1], frame.shape[0] // super_pixel_shape[0]),
+            interpolation=cv.INTER_LINEAR,
+        )
+    return ret, frame
+
+
+def capture_sample(video_source: str, num_frames: int, super_pixel_dimensions: Tuple[int, int]):
+    """Capture a fixed number of frames from the given video source."""
+    cap = cv.VideoCapture(video_source)
+    frames = []
+    for _ in range(num_frames):
+        ret, frame = get_next_frame(cap, super_pixel_dimensions)
+        if not ret:
+            break
+        frames.append(frame)
+    cap.release()
+    return frames
+
+
+def main():
+    """Continuously capture frame windows and process optical-flow metrics."""
+    # Determine which video source to use.  For now we favour the NVR
+    # stream but the logic is easily adaptable for other sources.
+    # is_webcam = True
+    # if len(sys.argv) > 1:
+    #     is_webcam = False
+    is_webcam = False
+    is_nvr = True
+
+    if is_webcam:
+        video_source = VIDEO_SOURCE["WEBCAM"]
+    elif is_nvr:
+        video_source = VIDEO_SOURCE["NVR"]
+    else:  # video source is a video file
+        # video_source = sys.argv[1]
+        video_source = VIDEO_SOURCE["FILE"]
+
+    super_pixel_dimensions = conf.DEFAULT_SUPER_PIXEL_DIMEMSNIONS  # can be modified
+
+    # Prepare metric extractors once
+    metric_extractors = {
+        "Lucas-Kanade": {"kwargs": conf.DEFAULT_LUCAS_KANADE_PARAMS, "function": extract_lucas_kanade_metric},
+        "Farneback": {"kwargs": conf.DEFAULT_FARNEBACK_PARAMS, "function": extract_farneback_metric},
+        "TVL1": {"kwargs": conf.DEFAULT_TVL1_PARAMS, "function": extract_TVL1_metric},
+    }
+
+    # Prepare the live chart UI and pair labels for frame comparisons
+    pair_labels = [f"1-{i}" for i in range(2, conf.FRAME_WINDOW_SIZE + 1)]
+    chart = live_bollinger_gui.MultiPairBollingerChart(
+        pair_labels, t_window=conf.T_WINDOW, num_std=conf.BOLLINGER_NUM_STD_OF_BANDS
+    )
+
+    capture_interval = conf.CAPTURE_INTERVAL_MINUTES * 60
+
+    while True:
+        # Capture a short sequence of frames from the source
+        frames = capture_sample(video_source, conf.FRAME_WINDOW_SIZE, super_pixel_dimensions)
+        if len(frames) < conf.FRAME_WINDOW_SIZE:
+            print("Failed to capture enough frames")
+            chart.wait_with_ui(capture_interval)
+            continue
+
+        now = datetime.now()
+        date_str = now.strftime("%Y%m%d")
+        output_file_path = f"./output/{date_str}.csv"
+        time_stamp = now.isoformat()
+
+        # Compare the first frame with every subsequent frame in the window
+        for idx in range(1, conf.FRAME_WINDOW_SIZE):
+            metrics = extract_metrics(frames[0], frames[idx], metric_extractors)
+            pair_label = f"1-{idx+1}"
+            append_metrics(output_file_path, metrics, time_stamp, pair_label)
+
+            data_dict = {
+                "Farneback_magnitude_mean": (
+                    metrics["Farneback"]["magnitude_mean"],
+                    metrics["Farneback"]["magnitude_deviation"],
+                )
+            }
+            flow = metrics["Farneback"].get("flow_matrix")
+            chart.push_new_data(data_dict, frame=frames[0], flow=flow, pair_name=pair_label)
+
+        # Wait before sampling again but keep the UI responsive
+        chart.wait_with_ui(capture_interval)
+
+    # Should never reach here but ensure clean up
+    cv.destroyAllWindows()
+
+
+if __name__ == '__main__':
+    main()

--- a/matplotlib_main.py
+++ b/matplotlib_main.py
@@ -104,10 +104,11 @@ def main():
             append_metrics(output_file_path, metrics, time_stamp, pair_label)
 
             data_dict = {
-                "Farneback_magnitude_mean": (
-                    metrics["Farneback"]["magnitude_mean"],
-                    metrics["Farneback"]["magnitude_deviation"],
+                algo: (
+                    metrics[algo]["magnitude_mean"],
+                    metrics[algo]["magnitude_deviation"],
                 )
+                for algo in metric_extractors.keys()
             }
             flow = metrics["Farneback"].get("flow_matrix")
             chart.push_new_data(data_dict, frame=frames[0], flow=flow, pair_name=pair_label)

--- a/matplotlib_main.py
+++ b/matplotlib_main.py
@@ -95,7 +95,7 @@ def main():
         now = datetime.now()
         date_str = now.strftime("%Y%m%d")
         output_file_path = os.path.join(conf.OUTPUT_DIR, f"{date_str}.csv")
-        time_stamp = now.isoformat()
+        time_stamp = now.strftime("%Y%m%d-%H%M")
 
         # Compare the first frame with every subsequent frame in the window
         for idx in range(1, conf.FRAME_WINDOW_SIZE):

--- a/metrics_extractor.py
+++ b/metrics_extractor.py
@@ -223,7 +223,7 @@ def append_metrics(output_path: str, metrics, time_units, pair_name: str = ""):
 
     If the file does not yet exist it will be created along with its
     parent directories and a header row.  Metrics are written in the
-    format ``metric_name,time,magnitude_mean,magnitude_deviation,
+    format ``pair,metric_name,time,magnitude_mean,magnitude_deviation,
     angular_deviation,angular_mean``.
 
     Parameters
@@ -236,8 +236,8 @@ def append_metrics(output_path: str, metrics, time_units, pair_name: str = ""):
     time_units:
         Time label to write for each row.  For example an ISO timestamp.
     pair_name:
-        Optional prefix added to the metric name to identify which frame
-        pair produced the measurement.
+        Label identifying which frame pair produced the measurement,
+        e.g. ``"1-2"``.
     """
     # Make sure all parent directories exist
     directory = os.path.dirname(output_path)
@@ -251,23 +251,26 @@ def append_metrics(output_path: str, metrics, time_units, pair_name: str = ""):
         writer = csv.writer(file)
         # Write header if this is a new file
         if not file_exists:
-            writer.writerow(["metric_name",
-                             "time",
-                             "magnitude_mean",
-                             "magnitude_deviation",
-                             "angular_deviation",
-                             "angular_mean"])
+            writer.writerow([
+                "pair",
+                "metric_name",
+                "time",
+                "magnitude_mean",
+                "magnitude_deviation",
+                "angular_deviation",
+                "angular_mean",
+            ])
 
         for metric_name in metrics.keys():
             # Append the data row
-            name = f"{pair_name}_{metric_name}" if pair_name else metric_name
             writer.writerow([
-                name,
+                pair_name,
+                metric_name,
                 time_units,
                 metrics[metric_name]['magnitude_mean'],
                 metrics[metric_name]['magnitude_deviation'],
                 metrics[metric_name]['angular_deviation'],
-                metrics[metric_name]['angular_mean']
+                metrics[metric_name]['angular_mean'],
             ])
 
 

--- a/metrics_worker.py
+++ b/metrics_worker.py
@@ -100,7 +100,7 @@ def _metrics_loop(stop_event: threading.Event):
 
     while not stop_event.is_set():
         frames = _capture_sample(video_source, conf.FRAME_WINDOW_SIZE, super_pixel_dimensions)
-        if len(frames) < 2:
+        if len(frames) < conf.FRAME_WINDOW_SIZE:
             stop_event.wait(capture_interval)
             continue
 
@@ -109,11 +109,13 @@ def _metrics_loop(stop_event: threading.Event):
         output_file_path = os.path.join(conf.OUTPUT_DIR, f'{date_str}.csv')
         time_stamp = now.isoformat()
 
-        metrics = extract_metrics(frames[0], frames[1], metric_extractors)
-        append_metrics(output_file_path, metrics, time_stamp, '1-2')
-
-        flow = metrics['Farneback'].get('flow_matrix')
-        _save_latest_frame(frames[0], flow, time_stamp)
+        for idx in range(1, conf.FRAME_WINDOW_SIZE):
+            metrics = extract_metrics(frames[0], frames[idx], metric_extractors)
+            pair_label = f'1-{idx+1}'
+            append_metrics(output_file_path, metrics, time_stamp, pair_label)
+            if idx == 1:
+                flow = metrics['Farneback'].get('flow_matrix')
+                _save_latest_frame(frames[0], flow, time_stamp)
 
         stop_event.wait(capture_interval)
 

--- a/metrics_worker.py
+++ b/metrics_worker.py
@@ -120,7 +120,7 @@ def _metrics_loop(stop_event: threading.Event):
         now = datetime.now()
         date_str = now.strftime('%Y%m%d')
         output_file_path = os.path.join(conf.OUTPUT_DIR, f'{date_str}.csv')
-        time_stamp = now.strftime('%Y%m%d-%H%M%S')
+        time_stamp = now.strftime('%Y%m%d-%H%M')
 
         flows = []
         for idx in range(1, conf.FRAME_WINDOW_SIZE):

--- a/metrics_worker.py
+++ b/metrics_worker.py
@@ -136,7 +136,7 @@ def _metrics_loop(stop_event: threading.Event):
         now = datetime.now()
         date_str = now.strftime('%Y%m%d')
         output_file_path = os.path.join(conf.OUTPUT_DIR, f'{date_str}.csv')
-        time_stamp = now.strftime('%Y%m%d-%H%M')
+        time_stamp = now.strftime(conf.TIMESTAMP_FORMAT)
 
         flows = []
         for idx in range(1, conf.FRAME_WINDOW_SIZE):

--- a/metrics_worker.py
+++ b/metrics_worker.py
@@ -81,8 +81,24 @@ def _save_frame_window(frames, flows, timestamp: str):
             fh.write(timestamp)
 
 
+def _prepare_output_paths():
+    """Ensure directories and placeholder files exist for metrics output."""
+    # Create output and frame directories
+    os.makedirs(conf.FRAMES_DIR, exist_ok=True)
+    os.makedirs(conf.OUTPUT_DIR, exist_ok=True)
+    # Touch latest-frame paths so later writes don't fail
+    for path in (conf.LATEST_FRAME_PATH, conf.LATEST_TS_PATH):
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        if not os.path.exists(path):
+            open(path, 'a', encoding='utf-8').close()
+
+
 def _metrics_loop(stop_event: threading.Event):
     """Continuously capture frames and update CSV/image outputs."""
+    _prepare_output_paths()
+
     is_webcam = False
     is_nvr = True
 

--- a/metrics_worker.py
+++ b/metrics_worker.py
@@ -19,28 +19,6 @@ from metrics_extractor import (
 )
 import cv_fish_configuration as conf
 
-# ---------------------------------------------------------------------------
-# Video source configuration
-# ---------------------------------------------------------------------------
-VIDOE_FILE_PATH = './Workable Data/Processed/DPH21_Above_IR10.avi'
-
-# TODO: fill the correct data for NVR source
-NVR_USER = 'admin'
-NVR_PASS = 'admin12345'
-NVR_IP = '0.0.0.0'  # within network
-NVR_PORT = '554'  # default port for the protocol, might not need change
-NVR_PATH = '/Streaming/Channels/101'
-
-VIDEO_SOURCE = {
-    'FILE': VIDOE_FILE_PATH,
-    'WEBCAM': 0,
-    'NVR': f"rtsp://{NVR_USER}:{NVR_PASS}@{NVR_IP}:{NVR_PORT}{NVR_PATH}"
-}
-
-OUTPUT_DIR = './output'
-LATEST_FRAME_PATH = os.path.join(OUTPUT_DIR, 'latest_frame.jpg')
-LATEST_TS_PATH = os.path.join(OUTPUT_DIR, 'latest_frame_timestamp.txt')
-
 
 def _get_next_frame(video_capture_object: cv.VideoCapture,
                     super_pixel_shape: Tuple[int, int] = conf.DEFAULT_SUPER_PIXEL_SHAPE):
@@ -83,10 +61,10 @@ def _draw_flow_quivers(frame, flow, step: int = 60):
 
 
 def _save_latest_frame(frame, flow, timestamp: str):
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    os.makedirs(conf.OUTPUT_DIR, exist_ok=True)
     vis = _draw_flow_quivers(frame, flow)
-    cv.imwrite(LATEST_FRAME_PATH, vis)
-    with open(LATEST_TS_PATH, 'w', encoding='utf-8') as fh:
+    cv.imwrite(conf.LATEST_FRAME_PATH, vis)
+    with open(conf.LATEST_TS_PATH, 'w', encoding='utf-8') as fh:
         fh.write(timestamp)
 
 
@@ -96,11 +74,11 @@ def _metrics_loop(stop_event: threading.Event):
     is_nvr = True
 
     if is_webcam:
-        video_source = VIDEO_SOURCE['WEBCAM']
+        video_source = conf.VIDEO_SOURCE['WEBCAM']
     elif is_nvr:
-        video_source = VIDEO_SOURCE['NVR']
+        video_source = conf.VIDEO_SOURCE['NVR']
     else:
-        video_source = VIDEO_SOURCE['FILE']
+        video_source = conf.VIDEO_SOURCE['FILE']
 
     super_pixel_dimensions = conf.DEFAULT_SUPER_PIXEL_DIMEMSNIONS
     capture_interval = conf.CAPTURE_INTERVAL_MINUTES * 60
@@ -128,7 +106,7 @@ def _metrics_loop(stop_event: threading.Event):
 
         now = datetime.now()
         date_str = now.strftime('%Y%m%d')
-        output_file_path = os.path.join(OUTPUT_DIR, f'{date_str}.csv')
+        output_file_path = os.path.join(conf.OUTPUT_DIR, f'{date_str}.csv')
         time_stamp = now.isoformat()
 
         metrics = extract_metrics(frames[0], frames[1], metric_extractors)

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,24 +3,36 @@
   <head>
     <meta charset="utf-8">
     <title>CV-Fish Dashboard</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/slate/bootstrap.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
-  <body class="p-4">
-    <h1 class="mb-4">CV-Fish Live Metrics</h1>
-    <div class="row">
-      <div class="col-md-8">
-        <select id="metricSelect" class="form-select mb-2"></select>
-        <canvas id="metricChart"></canvas>
+  <body>
+    <div class="container my-4">
+      <h1 class="mb-4 text-center">CV-Fish Live Metrics</h1>
+      <div class="row g-4">
+        <div class="col-md-8">
+          <div class="card">
+            <div class="card-body">
+              <select id="metricSelect" class="form-select mb-3"></select>
+              <canvas id="metricChart"></canvas>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card mb-4">
+            <div class="card-body">
+              <img id="latestFrame" class="img-fluid mb-3" alt="Latest frame" />
+              <div id="frameWindow" class="d-flex flex-column"></div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card-body">
+              <h2 class="h5">Worker Logs</h2>
+              <ul id="errorList" class="list-group list-group-flush"></ul>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="col-md-4">
-        <img id="latestFrame" class="img-fluid mb-2" alt="Latest frame" />
-        <div id="frameWindow" class="d-flex flex-column"></div>
-      </div>
-    </div>
-    <div class="mt-4">
-      <h2>Worker Logs</h2>
-      <ul id="errorList" class="list-group"></ul>
     </div>
 
     <script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,6 +60,7 @@
     const frameWindow = document.getElementById('frameWindow');
     const frameCache = {};
     let hoverTs = null;
+    let pinnedTs = null;
     const errorList = document.getElementById('errorList');
 
     metricSelect.addEventListener('change', () => {
@@ -141,6 +142,20 @@
       });
     }
 
+    function showFrames(ts) {
+      const frames = frameCache[ts];
+      if (!frames) return;
+      frameWindow.innerHTML = '';
+      frames.sort((a, b) => a.index - b.index).forEach(f => {
+        const img = document.createElement('img');
+        img.src = f.url;
+        img.alt = f.filename;
+        img.title = f.filename;
+        img.className = 'img-fluid mb-2';
+        frameWindow.appendChild(img);
+      });
+    }
+
     chart.canvas.addEventListener('mousemove', (evt) => {
       const points = chart.getElementsAtEventForMode(evt, 'nearest', {intersect: true}, true);
       if (points.length) {
@@ -148,18 +163,32 @@
         const ts = data.labels[idx];
         if (hoverTs === ts) return;
         hoverTs = ts;
-        const frames = frameCache[ts];
-        if (!frames) return;
-        frameWindow.innerHTML = '';
-        frames.sort((a, b) => a.index - b.index).forEach(f => {
-          const img = document.createElement('img');
-          img.src = f.url;
-          img.alt = f.filename;
-          img.title = f.filename;
-          img.className = 'img-fluid mb-2';
-          frameWindow.appendChild(img);
-        });
+        showFrames(ts);
+      } else {
+        hoverTs = null;
+        if (pinnedTs) {
+          showFrames(pinnedTs);
+        } else {
+          frameWindow.innerHTML = '';
+        }
       }
+    });
+
+    chart.canvas.addEventListener('mouseleave', () => {
+      hoverTs = null;
+      if (pinnedTs) {
+        showFrames(pinnedTs);
+      } else {
+        frameWindow.innerHTML = '';
+      }
+    });
+
+    chart.canvas.addEventListener('click', (evt) => {
+      const points = chart.getElementsAtEventForMode(evt, 'nearest', {intersect: true}, true);
+      if (!points.length) return;
+      const idx = points[0].index;
+      pinnedTs = data.labels[idx];
+      showFrames(pinnedTs);
     });
 
     fetchMetrics();

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,8 @@
         <canvas id="metricChart"></canvas>
       </div>
       <div class="col-md-4">
-        <img id="latestFrame" class="img-fluid" alt="Latest frame" />
+        <img id="latestFrame" class="img-fluid mb-2" alt="Latest frame" />
+        <div id="frameWindow" class="d-flex flex-column"></div>
       </div>
     </div>
 
@@ -26,9 +27,9 @@
     const data = {
       labels: [],
       datasets: [
-        {label: '', data: [], borderColor: 'blue', fill: false},
-        {label: 'Upper', data: [], borderColor: 'rgba(0,0,255,0.3)', fill: false},
-        {label: 'Lower', data: [], borderColor: 'rgba(0,0,255,0.3)', fill: false}
+        {label: '', data: [], borderColor: 'blue', fill: false, pointRadius: 3},
+        {label: 'Upper', data: [], borderColor: 'rgba(0,0,255,0.3)', fill: false, pointRadius: 0},
+        {label: 'Lower', data: [], borderColor: 'rgba(0,0,255,0.3)', fill: false, pointRadius: 0}
       ]
     };
     const chart = new Chart(ctx, {
@@ -36,6 +37,8 @@
       data,
       options: {animation: false, plugins: {title: {display: true, text: ''}}}
     });
+    const frameWindow = document.getElementById('frameWindow');
+    let hoverTs = null;
 
     metricSelect.addEventListener('change', () => {
       selectedMetric = metricSelect.value;
@@ -75,6 +78,26 @@
       const img = document.getElementById('latestFrame');
       img.src = '/frame?' + Date.now();
     }
+
+    chart.canvas.addEventListener('mousemove', async (evt) => {
+      const points = chart.getElementsAtEventForMode(evt, 'nearest', {intersect: true}, true);
+      if (points.length) {
+        const idx = points[0].index;
+        const ts = data.labels[idx];
+        if (hoverTs === ts) return;
+        hoverTs = ts;
+        const res = await fetch(`/frames/${ts}`);
+        if (!res.ok) return;
+        const json = await res.json();
+        frameWindow.innerHTML = '';
+        json.frames.filter(f => f.index !== 1).forEach(f => {
+          const img = document.createElement('img');
+          img.src = `/frames/${ts}/${f.index}`;
+          img.className = 'img-fluid mb-2';
+          frameWindow.appendChild(img);
+        });
+      }
+    });
 
     fetchMetrics();
     fetchFrame();

--- a/templates/index.html
+++ b/templates/index.html
@@ -78,7 +78,7 @@
     }
 
     async function fetchFrame() {
-      const res = await fetch('/frame?' + Date.now(), {cache: 'no-store'});
+      const res = await fetch('/frame', {cache: 'no-store'});
       if (!res.ok || res.status === 204) return;
       const blob = await res.blob();
       document.getElementById('latestFrame').src = URL.createObjectURL(blob);

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,10 @@
         <div id="frameWindow" class="d-flex flex-column"></div>
       </div>
     </div>
+    <div class="mt-4">
+      <h2>Worker Logs</h2>
+      <ul id="errorList" class="list-group"></ul>
+    </div>
 
     <script>
     const numStd = 2;
@@ -40,6 +44,7 @@
     const frameWindow = document.getElementById('frameWindow');
     const frameCache = {};
     let hoverTs = null;
+    const errorList = document.getElementById('errorList');
 
     metricSelect.addEventListener('change', () => {
       selectedMetric = metricSelect.value;
@@ -107,6 +112,19 @@
       }
     }
 
+    async function fetchLogs() {
+      const res = await fetch('/logs');
+      if (!res.ok) return;
+      const json = await res.json();
+      errorList.innerHTML = '';
+      json.logs.filter(l => l.level === 'error').forEach(log => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = `${log.timestamp}: ${log.message}`;
+        errorList.appendChild(li);
+      });
+    }
+
     chart.canvas.addEventListener('mousemove', (evt) => {
       const points = chart.getElementsAtEventForMode(evt, 'nearest', {intersect: true}, true);
       if (points.length) {
@@ -130,8 +148,10 @@
 
     fetchMetrics();
     fetchFrame();
+    fetchLogs();
     setInterval(fetchMetrics, 5000);
     setInterval(fetchFrame, 5000);
+    setInterval(fetchLogs, 5000);
     </script>
   </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,6 +95,8 @@
         json.frames.filter(f => f.index !== 1).forEach(f => {
           const img = document.createElement('img');
           img.src = `/frames/${ts}/${f.index}`;
+          img.alt = f.filename;
+          img.title = f.filename;
           img.className = 'img-fluid mb-2';
           frameWindow.appendChild(img);
         });

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>CV-Fish Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body class="p-4">
+    <h1 class="mb-4">CV-Fish Live Metrics</h1>
+    <div class="row">
+      <div class="col-md-8">
+        <canvas id="metricChart"></canvas>
+      </div>
+      <div class="col-md-4">
+        <img id="latestFrame" class="img-fluid" alt="Latest frame" />
+      </div>
+    </div>
+
+    <script>
+    const numStd = 2;
+    const ctx = document.getElementById('metricChart').getContext('2d');
+    const data = {
+      labels: [],
+      datasets: [
+        {label: 'Magnitude', data: [], borderColor: 'blue', fill: false},
+        {label: 'Upper', data: [], borderColor: 'rgba(0,0,255,0.3)', fill: false},
+        {label: 'Lower', data: [], borderColor: 'rgba(0,0,255,0.3)', fill: false}
+      ]
+    };
+    const chart = new Chart(ctx, {type: 'line', data, options: {animation: false}});
+
+    async function fetchMetrics() {
+      const res = await fetch('/metrics');
+      const json = await res.json();
+      const rows = json.metrics.filter(m => m.metric_name === '1-2_Farneback');
+      data.labels = rows.map(r => r.time);
+      const values = rows.map(r => parseFloat(r.magnitude_mean));
+      const stds = rows.map(r => parseFloat(r.magnitude_deviation));
+      data.datasets[0].data = values;
+      data.datasets[1].data = values.map((v, i) => v + numStd * stds[i]);
+      data.datasets[2].data = values.map((v, i) => v - numStd * stds[i]);
+      chart.update();
+    }
+
+    async function fetchFrame() {
+      const img = document.getElementById('latestFrame');
+      img.src = '/frame?' + Date.now();
+    }
+
+    fetchMetrics();
+    fetchFrame();
+    setInterval(fetchMetrics, 5000);
+    setInterval(fetchFrame, 5000);
+    </script>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
       const json = await res.json();
       const rows = json.metrics;
       const unique = Array.from(new Set(rows.map(r => `${r.pair}_${r.metric_name}`)));
-      if (!selectedMetric) {
+      if (!selectedMetric && unique.length) {
         selectedMetric = unique[0];
         unique.forEach(name => {
           const opt = document.createElement('option');
@@ -62,17 +62,18 @@
         metricSelect.value = selectedMetric;
       }
       const filtered = rows.filter(r => `${r.pair}_${r.metric_name}` === selectedMetric);
-      if (filtered.length === 0) return;
-      const label = selectedMetric.replace('_', ' ');
-      data.labels = filtered.map(r => r.time);
-      const values = filtered.map(r => parseFloat(r.magnitude_mean));
-      const stds = filtered.map(r => parseFloat(r.magnitude_deviation));
-      data.datasets[0].label = label;
-      chart.options.plugins.title.text = label;
-      data.datasets[0].data = values;
-      data.datasets[1].data = values.map((v, i) => v + numStd * stds[i]);
-      data.datasets[2].data = values.map((v, i) => v - numStd * stds[i]);
-      chart.update();
+      if (filtered.length) {
+        const label = selectedMetric.replace('_', ' ');
+        data.labels = filtered.map(r => r.time);
+        const values = filtered.map(r => parseFloat(r.magnitude_mean));
+        const stds = filtered.map(r => parseFloat(r.magnitude_deviation));
+        data.datasets[0].label = label;
+        chart.options.plugins.title.text = label;
+        data.datasets[0].data = values;
+        data.datasets[1].data = values.map((v, i) => v + numStd * stds[i]);
+        data.datasets[2].data = values.map((v, i) => v - numStd * stds[i]);
+        chart.update();
+      }
       await preloadFrames();
     }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -89,14 +89,19 @@
       const json = await res.json();
       for (const set of json.frame_sets) {
         if (!data.labels.includes(set.timestamp)) continue;
-        if (frameCache[set.timestamp]) continue;
-        frameCache[set.timestamp] = [];
+        const needed = set.frames.filter(f => f.index !== 1).length;
+        const cached = frameCache[set.timestamp]?.length || 0;
+        if (cached === needed) continue;
+        const frames = [];
         for (const f of set.frames) {
           if (f.index === 1) continue;
           const imgRes = await fetch(`/frames/${set.timestamp}/${f.index}`);
           if (!imgRes.ok) continue;
           const blob = await imgRes.blob();
-          frameCache[set.timestamp].push({index: f.index, url: URL.createObjectURL(blob), filename: f.filename});
+          frames.push({index: f.index, url: URL.createObjectURL(blob), filename: f.filename});
+        }
+        if (frames.length) {
+          frameCache[set.timestamp] = frames;
         }
       }
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,6 +38,7 @@
       options: {animation: false, plugins: {title: {display: true, text: ''}}}
     });
     const frameWindow = document.getElementById('frameWindow');
+    const frameCache = {};
     let hoverTs = null;
 
     metricSelect.addEventListener('change', () => {
@@ -72,6 +73,7 @@
       data.datasets[1].data = values.map((v, i) => v + numStd * stds[i]);
       data.datasets[2].data = values.map((v, i) => v - numStd * stds[i]);
       chart.update();
+      await preloadFrames();
     }
 
     async function fetchFrame() {
@@ -81,20 +83,37 @@
       document.getElementById('latestFrame').src = URL.createObjectURL(blob);
     }
 
-    chart.canvas.addEventListener('mousemove', async (evt) => {
+    async function preloadFrames() {
+      const res = await fetch('/frames/all');
+      if (!res.ok) return;
+      const json = await res.json();
+      for (const set of json.frame_sets) {
+        if (!data.labels.includes(set.timestamp)) continue;
+        if (frameCache[set.timestamp]) continue;
+        frameCache[set.timestamp] = [];
+        for (const f of set.frames) {
+          if (f.index === 1) continue;
+          const imgRes = await fetch(`/frames/${set.timestamp}/${f.index}`);
+          if (!imgRes.ok) continue;
+          const blob = await imgRes.blob();
+          frameCache[set.timestamp].push({index: f.index, url: URL.createObjectURL(blob), filename: f.filename});
+        }
+      }
+    }
+
+    chart.canvas.addEventListener('mousemove', (evt) => {
       const points = chart.getElementsAtEventForMode(evt, 'nearest', {intersect: true}, true);
       if (points.length) {
         const idx = points[0].index;
         const ts = data.labels[idx];
         if (hoverTs === ts) return;
         hoverTs = ts;
-        const res = await fetch(`/frames/${ts}`);
-        if (!res.ok) return;
-        const json = await res.json();
+        const frames = frameCache[ts];
+        if (!frames) return;
         frameWindow.innerHTML = '';
-        json.frames.filter(f => f.index !== 1).forEach(f => {
+        frames.sort((a, b) => a.index - b.index).forEach(f => {
           const img = document.createElement('img');
-          img.src = `/frames/${ts}/${f.index}`;
+          img.src = f.url;
           img.alt = f.filename;
           img.title = f.filename;
           img.className = 'img-fluid mb-2';

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,8 +75,10 @@
     }
 
     async function fetchFrame() {
-      const img = document.getElementById('latestFrame');
-      img.src = '/frame?' + Date.now();
+      const res = await fetch('/frame?' + Date.now(), {cache: 'no-store'});
+      if (!res.ok || res.status === 204) return;
+      const blob = await res.blob();
+      document.getElementById('latestFrame').src = URL.createObjectURL(blob);
     }
 
     chart.canvas.addEventListener('mousemove', async (evt) => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,10 @@
               <div id="frameWindow" class="d-flex flex-column"></div>
             </div>
           </div>
+        </div>
+      </div>
+      <div class="row mt-4">
+        <div class="col">
           <div class="card">
             <div class="card-body">
               <h2 class="h5">Worker Logs</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
     <h1 class="mb-4">CV-Fish Live Metrics</h1>
     <div class="row">
       <div class="col-md-8">
+        <select id="metricSelect" class="form-select mb-2"></select>
         <canvas id="metricChart"></canvas>
       </div>
       <div class="col-md-4">
@@ -19,24 +20,51 @@
 
     <script>
     const numStd = 2;
+    const metricSelect = document.getElementById('metricSelect');
+    let selectedMetric = null;
     const ctx = document.getElementById('metricChart').getContext('2d');
     const data = {
       labels: [],
       datasets: [
-        {label: 'Magnitude', data: [], borderColor: 'blue', fill: false},
+        {label: '', data: [], borderColor: 'blue', fill: false},
         {label: 'Upper', data: [], borderColor: 'rgba(0,0,255,0.3)', fill: false},
         {label: 'Lower', data: [], borderColor: 'rgba(0,0,255,0.3)', fill: false}
       ]
     };
-    const chart = new Chart(ctx, {type: 'line', data, options: {animation: false}});
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data,
+      options: {animation: false, plugins: {title: {display: true, text: ''}}}
+    });
+
+    metricSelect.addEventListener('change', () => {
+      selectedMetric = metricSelect.value;
+      fetchMetrics();
+    });
 
     async function fetchMetrics() {
       const res = await fetch('/metrics');
       const json = await res.json();
-      const rows = json.metrics.filter(m => m.metric_name === '1-2_Farneback');
-      data.labels = rows.map(r => r.time);
-      const values = rows.map(r => parseFloat(r.magnitude_mean));
-      const stds = rows.map(r => parseFloat(r.magnitude_deviation));
+      const rows = json.metrics;
+      const unique = Array.from(new Set(rows.map(r => `${r.pair}_${r.metric_name}`)));
+      if (!selectedMetric) {
+        selectedMetric = unique[0];
+        unique.forEach(name => {
+          const opt = document.createElement('option');
+          opt.value = name;
+          opt.textContent = name.replace('_', ' ');
+          metricSelect.appendChild(opt);
+        });
+        metricSelect.value = selectedMetric;
+      }
+      const filtered = rows.filter(r => `${r.pair}_${r.metric_name}` === selectedMetric);
+      if (filtered.length === 0) return;
+      const label = selectedMetric.replace('_', ' ');
+      data.labels = filtered.map(r => r.time);
+      const values = filtered.map(r => parseFloat(r.magnitude_mean));
+      const stds = filtered.map(r => parseFloat(r.magnitude_deviation));
+      data.datasets[0].label = label;
+      chart.options.plugins.title.text = label;
       data.datasets[0].data = values;
       data.datasets[1].data = values.map((v, i) => v + numStd * stds[i]);
       data.datasets[2].data = values.map((v, i) => v - numStd * stds[i]);


### PR DESCRIPTION
## Summary
- Add background metrics thread that captures frames, writes metrics to CSV, and saves quiver-annotated frames.
- Expose Flask REST API endpoints for metrics JSON and latest frame image with timestamps.
- Provide simple Bootstrap + Chart.js dashboard to display Bollinger-style graph and latest frame.
- Include Flask dependency in environment specification.

## Testing
- `python -m py_compile main.py metrics_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac61501e44832d907ceb44176a2bca